### PR TITLE
fix: added Missing test cases for cleanup of the databases and updated the readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.0--beta.1-blue" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.1.0--beta.4-blue" alt="Version" />
   <img src="https://img.shields.io/badge/license-MIT-green" alt="License" />
   <img src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux-lightgrey" alt="Platform" />
-  <img src="https://img.shields.io/badge/databases-PostgreSQL%20%7C%20MySQL-orange" alt="Databases" />
+  <img src="https://img.shields.io/badge/databases-PostgreSQL%20%7C%20MySQL%20%7C%20MariaDB-orange" alt="Databases" />
 </p>
 
 <p align="center">
   <a href="https://github.com/Yashh56/RelWave/releases"><strong>Download</strong></a> |
-  <a href="#-features"><strong>Features</strong></a> |
-  <a href="#-installation"><strong>Installation</strong></a> |
-  <a href="#-contributing"><strong>Contributing</strong></a>
+  <a href="#Features"><strong>Features</strong></a> |
+  <a href="#Installation"><strong>Installation</strong></a> |
+  <a href="#Contributing"><strong>Contributing</strong></a>
 </p>
 
 ---
@@ -232,9 +232,69 @@ Database connection configurations are stored in:
 
 ### Running Tests
 
+The bridge includes a comprehensive test suite with integration tests for database connectors.
+
+#### Prerequisites
+
+1. **Docker** - Required for running test databases:
+
+```bash
+cd bridge
+docker-compose -f docker-compose.test.yml up -d
+```
+
+This starts PostgreSQL, MySQL, and MariaDB containers for testing.
+
+2. **Environment Variables** - Create a `.env` file in the `bridge` directory:
+
+```env
+# PostgreSQL Test Configuration
+REAL_POSTGRES_HOST=localhost
+REAL_POSTGRES_PORT=5432
+REAL_POSTGRES_USER=testuser
+REAL_POSTGRES_PASSWORD=testpass
+REAL_POSTGRES_DATABASE=testdb
+REAL_POSTGRES_SSL=false
+
+# MySQL Test Configuration
+REAL_MYSQL_HOST=localhost
+REAL_MYSQL_PORT=3306
+REAL_MYSQL_USER=testuser
+REAL_MYSQL_PASSWORD=testpass
+REAL_MYSQL_DATABASE=testdb
+
+# MariaDB Test Configuration
+REAL_MARIADB_HOST=localhost
+REAL_MARIADB_PORT=3307
+REAL_MARIADB_USER=testuser
+REAL_MARIADB_PASSWORD=testpass
+REAL_MARIADB_DATABASE=testdb
+```
+
+#### Running Tests
+
 ```bash
 cd bridge
 pnpm test
+```
+
+#### Test Suites
+
+| Test Suite | Description |
+|------------|-------------|
+| `databaseService.test.ts` | Database service CRUD operations and validation |
+| `dbStore.test.ts` | Database store caching, encryption, and persistence |
+| `connectionBuilder.test.ts` | Connection configuration building |
+| `postgres.test.ts` | PostgreSQL connector integration tests |
+| `mysql.test.ts` | MySQL connector integration tests |
+| `mariadb.test.ts` | MariaDB connector integration tests |
+| `*.cache.test.ts` | Query result caching tests for each connector |
+
+#### Stopping Test Databases
+
+```bash
+cd bridge
+docker-compose -f docker-compose.test.yml down
 ```
 
 ### Architecture

--- a/bridge/__tests__/dbStore.test.ts
+++ b/bridge/__tests__/dbStore.test.ts
@@ -12,7 +12,7 @@ const TEST_CREDENTIALS_FILE = path.join(TEST_CONFIG_FOLDER, ".credentials");
 const TEST_ENCRYPTION_KEY = "test-encryption-key";
 
 // Short TTL for testing cache expiration
-const SHORT_CACHE_TTL = 100; // 100ms for testing
+const SHORT_CACHE_TTL = 200; // 200ms for testing
 const NORMAL_CACHE_TTL = 30000; // 30 seconds
 
 const mockDBPayload = {
@@ -207,8 +207,8 @@ describe("DbStore Cache Tests", () => {
       // Cache should be populated after addDB (saveAll updates cache)
       expect(shortTtlStore.getCacheStats().configCached).toBe(true);
 
-      // Wait for TTL to expire
-      await new Promise((resolve) => setTimeout(resolve, SHORT_CACHE_TTL + 50));
+      // Wait for TTL to expire (add extra buffer for system lag)
+      await new Promise((resolve) => setTimeout(resolve, SHORT_CACHE_TTL + 150));
 
       // Cache should be expired now
       expect(shortTtlStore.getCacheStats().configCached).toBe(false);


### PR DESCRIPTION
This pull request improves the documentation and reliability of the database service and store tests. It adds more comprehensive test coverage for database deletion, strengthens test cleanup logic to avoid leftover test databases, and updates the documentation to clarify test setup and supported databases.

**Documentation improvements:**

* Updated `README.md` to reflect support for MariaDB, clarified navigation links, and added detailed instructions for running integration tests with Docker and environment variables. Also included a summary of available test suites and cleanup steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R235-R299)

**Testing reliability and coverage:**

* Enhanced cleanup logic in `databaseService.test.ts` to ensure all test databases are deleted after tests, using both tracked IDs and a safety-net name filter.
* Added new test cases to `databaseService.test.ts` for successful deletion of a database and for error handling when attempting to delete a non-existent database.
* Increased cache expiration buffer and TTL in `dbStore.test.ts` to reduce flakiness due to timing issues. [[1]](diffhunk://#diff-b35a5f89a2ec20683b2a7bfedec042dcb9ca3c40bebcaf2bd61c74004fbaf6f5L15-R15) [[2]](diffhunk://#diff-b35a5f89a2ec20683b2a7bfedec042dcb9ca3c40bebcaf2bd61c74004fbaf6f5L210-R211)

**General test improvements:**

* Removed redundant instantiations of `DatabaseService` in each test case, streamlining the test code. [[1]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL49) [[2]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL60) [[3]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL71) [[4]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL82) [[5]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL93) [[6]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL104) [[7]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL115) [[8]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL127) [[9]](diffhunk://#diff-bd05993a3b08063b7fae77f1da2574ec62379872a78756627eb473978c56636dL138)