### PR TITLE
feat: Enhance analytics functionality and improve telemetry logging

### DIFF
--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relwave-bridge",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "commonjs",
   "main": "dist/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "relwave",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -53,6 +53,9 @@ async fn main() {
                 
             if has_aptabase && is_analytics_enabled {
                 let _ = app.track_event("app_started", None);
+                println!("🚀 Analytics is ON: Successfully dispatched 'app_started' event.");
+            } else if has_aptabase && !is_analytics_enabled {
+                println!("🛑 Analytics is OFF: User opted out, no telemetry will be sent.");
             }
 
             app.manage(analytics);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -44,19 +44,23 @@ async fn main() {
     builder
         .setup(|app| {
             let analytics = AnalyticsService::new(app.handle());
-            let is_analytics_enabled = tauri::async_runtime::block_on(analytics.is_enabled());
-
-            let has_aptabase = option_env!("APTABASE_APP_KEY")
-                .map(String::from)
-                .or_else(|| std::env::var("APTABASE_APP_KEY").ok())
-                .is_some();
+            let analytics_clone = analytics.clone();
+            let app_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let is_analytics_enabled = analytics_clone.is_enabled().await;
                 
-            if has_aptabase && is_analytics_enabled {
-                let _ = app.track_event("app_started", None);
-                println!("🚀 Analytics is ON: Successfully dispatched 'app_started' event.");
-            } else if has_aptabase && !is_analytics_enabled {
-                println!("🛑 Analytics is OFF: User opted out, no telemetry will be sent.");
-            }
+                let has_aptabase = option_env!("APTABASE_APP_KEY")
+                    .map(String::from)
+                    .or_else(|| std::env::var("APTABASE_APP_KEY").ok())
+                    .is_some();
+                    
+                if has_aptabase && is_analytics_enabled {
+                    let _ = app_handle.track_event("app_started", None);
+                    println!("🚀 Analytics is ON: Successfully dispatched 'app_started' event.");
+                } else if has_aptabase && !is_analytics_enabled {
+                    println!("🛑 Analytics is OFF: User opted out, no telemetry will be sent.");
+                }
+            });
 
             app.manage(analytics);
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -43,16 +43,18 @@ async fn main() {
 
     builder
         .setup(|app| {
+            let analytics = AnalyticsService::new(app.handle());
+            let is_analytics_enabled = tauri::async_runtime::block_on(analytics.is_enabled());
+
             let has_aptabase = option_env!("APTABASE_APP_KEY")
                 .map(String::from)
                 .or_else(|| std::env::var("APTABASE_APP_KEY").ok())
                 .is_some();
                 
-            if has_aptabase {
+            if has_aptabase && is_analytics_enabled {
                 let _ = app.track_event("app_started", None);
             }
 
-            let analytics = AnalyticsService::new(app.handle());
             app.manage(analytics);
 
             let handle = app.handle().clone();

--- a/src-tauri/src/services/analytics.rs
+++ b/src-tauri/src/services/analytics.rs
@@ -45,9 +45,9 @@ impl AnalyticsService {
         }
 
         if enabled {
-            println!("Analytics have been enabled by the user.");
+            println!("🚀 Analytics have been enabled by the user. Events will now be sent.");
         } else {
-            println!("Analytics have been disabled by the user.");
+            println!("🛑 Analytics have been disabled by the user. Tracking stopped.");
         }
     }
 }

--- a/src-tauri/src/services/analytics.rs
+++ b/src-tauri/src/services/analytics.rs
@@ -1,16 +1,31 @@
 use std::sync::Arc;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 use tokio::sync::RwLock;
+use std::fs;
 
 #[derive(Clone)]
 pub struct AnalyticsService {
     enabled: Arc<RwLock<bool>>,
+    app_handle: AppHandle,
 }
 
 impl AnalyticsService {
-    pub fn new(_app: &AppHandle) -> Self {
+    pub fn new(app: &AppHandle) -> Self {
+        let mut enabled = false;
+        if let Ok(path) = app.path().app_data_dir() {
+            let config_path = path.join("analytics.json");
+            if let Ok(content) = fs::read_to_string(&config_path) {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(e) = val.get("enabled").and_then(|v| v.as_bool()) {
+                        enabled = e;
+                    }
+                }
+            }
+        }
+        
         Self {
-            enabled: Arc::new(RwLock::new(false)),
+            enabled: Arc::new(RwLock::new(enabled)),
+            app_handle: app.clone(),
         }
     }
 
@@ -21,6 +36,14 @@ impl AnalyticsService {
     pub async fn set_enabled(&self, enabled: bool) {
         let mut e = self.enabled.write().await;
         *e = enabled;
+        
+        if let Ok(path) = self.app_handle.path().app_data_dir() {
+            let _ = fs::create_dir_all(&path);
+            let config_path = path.join("analytics.json");
+            let content = serde_json::json!({ "enabled": enabled }).to_string();
+            let _ = fs::write(&config_path, content);
+        }
+
         if enabled {
             println!("Analytics have been enabled by the user.");
         } else {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RelWave",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "tech.relwave.app",
   "build": {
     "beforeDevCommand": "vite",


### PR DESCRIPTION
This pull request updates the application to version 1.0.2 and introduces improvements to analytics tracking and configuration persistence. The most important changes are grouped below:

**Analytics Configuration and Persistence:**

* The `AnalyticsService` now reads the user's analytics preference from an `analytics.json` file in the app data directory at startup, ensuring analytics are enabled or disabled based on persisted user choice.
* When the user changes their analytics preference, the new value is saved back to `analytics.json`, making the setting persistent across app restarts.

**Analytics Event Dispatching:**

* The app now checks both the presence of an analytics key and the user's enabled setting before sending the `app_started` event, and logs clearly whether analytics are on or off.

**Version Bump:**

* Application version updated from `1.0.1` to `1.0.2` in `package.json`, `bridge/package.json`, and `src-tauri/tauri.conf.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4) [[2]](diffhunk://#diff-f8dff21fa5b738c190d3d3cf5812b7fdff27bd896dd23b50cdfafe8a42ba23a8L3-R3) [[3]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L4-R4)